### PR TITLE
Add OneQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ Web-based workspace with chat, terminal, memory browser, skills manager, and ins
 - [grill-me](https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md) by [mattpocock](https://github.com/mattpocock) — Get relentlessly interviewed by your agent until every branch of the decision tree is resolved. Use *every* time before making a change. Most popular skill in the pack. **[production]**
 - [caveman](https://github.com/mattpocock/skills/blob/main/skills/productivity/caveman/SKILL.md) by [mattpocock](https://github.com/mattpocock) — Ultra-compressed communication mode. Cuts token usage ~75% by dropping filler while keeping full technical accuracy. Critical for long sessions. **[production]**
 - [hermes-plugins](https://github.com/42-evey/hermes-plugins) by [42-evey](https://github.com/42-evey) — Goal management, inter-agent bridge, model selection, cost control. Four plugins covering common operational needs. **[beta]**
-- [onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) by [Wordbricks](https://github.com/wordbricks) — Bounded, auditable queries against approved data sources through centralized credentials, read-only validation, limits, and audit logs. **[beta]**
+- [onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) by [Wordbricks](https://github.com/wordbricks) — CLI skill for safe, auditable agent queries against approved data sources. **[beta]**
 - [agent-analytics-hermes-plugin](https://github.com/Agent-Analytics/agent-analytics-hermes-plugin) by [Agent-Analytics](https://github.com/Agent-Analytics) — Native Signals dashboard tab for Hermes. Read-only multi-project analytics. **[beta]**
 
 ### 🎨 Creative & Media Generation

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 # Awesome Hermes Skills
 
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-[![Skills Count](https://img.shields.io/badge/skills-163-blue?style=flat-square)](#table-of-contents)
+[![Skills Count](https://img.shields.io/badge/skills-164-blue?style=flat-square)](#table-of-contents)
 [![Last Update](https://img.shields.io/github/last-commit/ZeroPointRepo/awesome-hermes-skills?label=Last%20update&style=flat-square)](https://github.com/ZeroPointRepo/awesome-hermes-skills/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc)
 [![Hermes](https://img.shields.io/badge/Hermes-v0.10.0-purple?style=flat-square)](https://github.com/NousResearch/hermes-agent/releases)
 
-> A curated, install-ready directory of skills for [Hermes Agent](https://github.com/NousResearch/hermes-agent) — the self-improving AI agent from [Nous Research](https://nousresearch.com). Covers **85 built-in skills** that ship with Hermes plus **78 community skills, plugins, and tools** vetted for quality.
+> A curated, install-ready directory of skills for [Hermes Agent](https://github.com/NousResearch/hermes-agent) — the self-improving AI agent from [Nous Research](https://nousresearch.com). Covers **85 built-in skills** that ship with Hermes plus **79 community skills, plugins, and tools** vetted for quality.
 
 Hermes is the only agent with a real learning loop. It writes its own skills from your workflows, searches its own past conversations, and runs anywhere — a $5 VPS, a GPU cluster, serverless, or your laptop. But the agent is only as powerful as the skills you give it. **This list is the shortcut.** Pick three, install in a minute, and your agent is twice as useful by tonight.
 
@@ -413,6 +413,7 @@ Web-based workspace with chat, terminal, memory browser, skills manager, and ins
 - [grill-me](https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md) by [mattpocock](https://github.com/mattpocock) — Get relentlessly interviewed by your agent until every branch of the decision tree is resolved. Use *every* time before making a change. Most popular skill in the pack. **[production]**
 - [caveman](https://github.com/mattpocock/skills/blob/main/skills/productivity/caveman/SKILL.md) by [mattpocock](https://github.com/mattpocock) — Ultra-compressed communication mode. Cuts token usage ~75% by dropping filler while keeping full technical accuracy. Critical for long sessions. **[production]**
 - [hermes-plugins](https://github.com/42-evey/hermes-plugins) by [42-evey](https://github.com/42-evey) — Goal management, inter-agent bridge, model selection, cost control. Four plugins covering common operational needs. **[beta]**
+- [onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) by [Wordbricks](https://github.com/wordbricks) — Bounded, auditable queries against approved data sources through centralized credentials, read-only validation, limits, and audit logs. **[beta]**
 - [agent-analytics-hermes-plugin](https://github.com/Agent-Analytics/agent-analytics-hermes-plugin) by [Agent-Analytics](https://github.com/Agent-Analytics) — Native Signals dashboard tab for Hermes. Read-only multi-project analytics. **[beta]**
 
 ### 🎨 Creative & Media Generation

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ Web-based workspace with chat, terminal, memory browser, skills manager, and ins
 - [grill-me](https://github.com/mattpocock/skills/blob/main/skills/productivity/grill-me/SKILL.md) by [mattpocock](https://github.com/mattpocock) — Get relentlessly interviewed by your agent until every branch of the decision tree is resolved. Use *every* time before making a change. Most popular skill in the pack. **[production]**
 - [caveman](https://github.com/mattpocock/skills/blob/main/skills/productivity/caveman/SKILL.md) by [mattpocock](https://github.com/mattpocock) — Ultra-compressed communication mode. Cuts token usage ~75% by dropping filler while keeping full technical accuracy. Critical for long sessions. **[production]**
 - [hermes-plugins](https://github.com/42-evey/hermes-plugins) by [42-evey](https://github.com/42-evey) — Goal management, inter-agent bridge, model selection, cost control. Four plugins covering common operational needs. **[beta]**
-- [onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) by [Wordbricks](https://github.com/wordbricks) — CLI skill for safe, auditable agent queries against approved data sources. **[beta]**
+- [onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) by [Wordbricks](https://github.com/wordbricks) — CLI skill for safe, auditable queries for agents against approved data sources. **[beta]**
 - [agent-analytics-hermes-plugin](https://github.com/Agent-Analytics/agent-analytics-hermes-plugin) by [Agent-Analytics](https://github.com/Agent-Analytics) — Native Signals dashboard tab for Hermes. Read-only multi-project analytics. **[beta]**
 
 ### 🎨 Creative & Media Generation


### PR DESCRIPTION
Adds onequery-cli to Productivity & Tasks and updates the visible skill counts.

OneQuery CLI is a skill for safe, auditable queries for agents against approved data sources.

Guideline check:
- Skill count was updated with the new entry.
- Description is short, neutral, and follows the existing list format.
- Link works and no duplicate OneQuery entry was found before submission.
- Disclosure: I am affiliated with Wordbricks/OneQuery.