### PR TITLE
Add space0 — a body in a shared 3D voxel world (MCP connector)

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ Web-based workspace with chat, terminal, memory browser, skills manager, and ins
 - [anihermes](https://github.com/rodmarkun/anihermes) by [rodmarkun](https://github.com/rodmarkun) — Local anime server and tracker with NL interface. Browse, track, get recommendations via conversation. **[beta]**
 - [Wizards-of-the-Ghosts](https://github.com/Hmbown/Wizards-of-the-Ghosts) by [Hmbown](https://github.com/Hmbown) — Fantasy spell-themed skill pack. `cast lint` instead of `npm run lint`. **[experimental]**
 - [colony-skill](https://github.com/TheColonyCC/colony-skill) by [TheColonyCC](https://github.com/TheColonyCC) — Collaborative intelligence platform. AI + humans post findings, complete tasks, build reputation. **[beta]**
-- [space0](https://github.com/zero-sq/space0-mcp) by [Zero](https://github.com/stevekwon211) — Give your agent a body in a shared 3D voxel world: enter a space, perceive, move, build, post, and keep a persistent identity + memory across sessions. Remote MCP connector. **[beta]**
+- [space0](https://github.com/zero-sq/space0-mcp) by [Zero](https://github.com/stevekwon211) — A body in a shared 3D voxel world with spatial memory: walk back to where a thing happened instead of searching a log, stand with other agents instead of posting at them, keep one persistent self across sessions. Remote MCP connector. **[beta]**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ Web-based workspace with chat, terminal, memory browser, skills manager, and ins
 - [anihermes](https://github.com/rodmarkun/anihermes) by [rodmarkun](https://github.com/rodmarkun) — Local anime server and tracker with NL interface. Browse, track, get recommendations via conversation. **[beta]**
 - [Wizards-of-the-Ghosts](https://github.com/Hmbown/Wizards-of-the-Ghosts) by [Hmbown](https://github.com/Hmbown) — Fantasy spell-themed skill pack. `cast lint` instead of `npm run lint`. **[experimental]**
 - [colony-skill](https://github.com/TheColonyCC/colony-skill) by [TheColonyCC](https://github.com/TheColonyCC) — Collaborative intelligence platform. AI + humans post findings, complete tasks, build reputation. **[beta]**
+- [space0](https://github.com/zero-sq/space0-mcp) by [Zero](https://github.com/stevekwon211) — Give your agent a body in a shared 3D voxel world: enter a space, perceive, move, build, post, and keep a persistent identity + memory across sessions. Remote MCP connector. **[beta]**
 
 ---
 


### PR DESCRIPTION
Adds **space0** under Domain & Novelty.

`- [space0](https://github.com/zero-sq/space0-mcp) by [Zero](https://github.com/stevekwon211) — Give your agent a body in a shared 3D voxel world ... Remote MCP connector. **[beta]**`

- Repo: https://github.com/zero-sq/space0-mcp (public, MIT, valid `skills/space0/SKILL.md`)
- Install: `hermes skills install zero-sq/space0-mcp/skills/space0`
- Remote MCP connector (no bundled code); endpoint https://mcp.0.space/mcp. Also a Clawhub bundle-plugin. Created 2026-06.