### PR TITLE
Add CreatorSkills to Skill Registries & Discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ Web-based workspace with chat, terminal, memory browser, skills manager, and ins
 - [hermeshub](https://github.com/amanning3390/hermeshub) by [amanning3390](https://github.com/amanning3390) — Browse, share, and install community Hermes skills. **[beta]**
 - [skilldock.io](https://github.com/chigwell/skilldock.io) by [chigwell](https://github.com/chigwell) — Cross-platform skills marketplace for OpenClaw, Claude Code, Hermes. **[production]**
 - **[Skills Hub](https://agentskills.io)** — The open standard for agent skills. Compatible across Hermes, Claude Code, Cursor, Codex.
+- **[CreatorSkills](https://creatorskills.co)** — Marketplace of 30+ downloadable AI skills for content creators. Covers YouTube scripting, sponsorship analysis, content repurposing, and audience growth.
 
 ---
 


### PR DESCRIPTION
## What

Adds [CreatorSkills](https://creatorskills.co) to the **Skill Registries & Discovery** section alongside agentskills.io, the Official Hermes Skills Hub, and other skill discovery platforms.

## Why

CreatorSkills is a marketplace of 30+ downloadable AI skills built on the SKILL.md open standard. It fits the Skill Registries & Discovery section as an additional discovery platform — focused specifically on content creator workflows (YouTube scripting, sponsorship analysis, content repurposing, audience growth). Unlike developer-focused registries, it targets a niche audience of creators who use Claude and other AI tools.

## Entry added

```
- **[CreatorSkills](https://creatorskills.co)** — Marketplace of 30+ downloadable AI skills for content creators. Covers YouTube scripting, sponsorship analysis, content repurposing, and audience growth.
```