### PR TITLE
Add erpclaw (AI-native open-source ERP + accounting) to Finance, Payments & Crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ Web-based workspace with chat, terminal, memory browser, skills manager, and ins
 - [hermes-blockchain-oracle](https://github.com/gizdusum/hermes-blockchain-oracle) by [gizdusum](https://github.com/gizdusum) — Solana blockchain intelligence MCP server. On-chain analytics and wallet data. **[experimental]**
 - [chainlink-agent-skills](https://github.com/smartcontractkit/chainlink-agent-skills) by [Chainlink](https://github.com/smartcontractkit) — Official Chainlink skills. Oracle data, CCIP, smart contract interaction. **[production]**
 - [mercury](https://github.com/hxsteric/mercury) by [hxsteric](https://github.com/hxsteric) — Multi-chain blockchain cash flow analyzer with WebGL dashboard. On-chain forensics. **[beta]**
+- [erpclaw](https://github.com/avansaber/erpclaw) by [AvanSaber](https://github.com/avansaber) — AI-native open-source ERP and double-entry accounting you self-host and run in plain English. Invoicing, inventory, general ledger, payroll, multi-company books. **[beta]**
 
 ### 🤖 Multi-Agent & Swarms
 


### PR DESCRIPTION
Adding **erpclaw** under Finance, Payments & Crypto — the section is all crypto/payments today; this adds traditional ERP + double-entry accounting.

**What it is:** AI-native, open-source (GPL v3), self-hosted ERP + accounting driven in plain English — invoicing, inventory, general ledger, payroll, multi-company books in one shared database.
**Repo / working example:** https://github.com/avansaber/erpclaw (agentskills.io `SKILL.md`, README, tests).
**Install:** `hermes skills tap add avansaber/erpclaw`

Meets the contributing bar: working `SKILL.md`, maintained, clear README + one-line install, not already listed. Tagged **[beta]** (production-grade on OpenClaw; Hermes support newly added).