### PR TITLE
Add nika under DevOps & Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ Web-based workspace with chat, terminal, memory browser, skills manager, and ins
 
 - [hermes-agent-docker](https://github.com/xmbshwll/hermes-agent-docker) by [xmbshwll](https://github.com/xmbshwll) — Minimal Docker sandbox image for Hermes. Pull, run, done. **[beta]**
 - [portainer-stack-hermes](https://github.com/ellickjohnson/portainer-stack-hermes) by [ellickjohnson](https://github.com/ellickjohnson) — Docker Compose + Portainer + ttyd web terminal. Browser-accessible Hermes. **[experimental]**
+- [nika](https://github.com/supernovae-st/nika) by [supernovae-st](https://github.com/supernovae-st) — Deterministic workflow runner Hermes can delegate to. Repeatable AI jobs become reviewable .nika.yaml files, checked before a token is spent (plan, cost floor, secret flows, permits) and tamper-evident after via a hash-chained trace. Install: brew install supernovae-st/tap/nika. **[beta]**
 - [nix-hermes-agent](https://github.com/0xrsydn/nix-hermes-agent) by [0xrsydn](https://github.com/0xrsydn) — Nix package and NixOS module. Fully reproducible deployments via Nix flakes. **[beta]**
 - [openclaw-to-hermes](https://github.com/0xNyk/openclaw-to-hermes) by [0xNyk](https://github.com/0xNyk) — Community migration tool from OpenClaw to Hermes. **[beta]**
 - [evey-setup](https://github.com/42-evey/evey-setup) by [42-evey](https://github.com/42-evey) — One-command setup for full hermes-agent stack with free models and 29 plugins. **[beta]**


### PR DESCRIPTION
Disclosure: I maintain nika (github.com/supernovae-st/nika), an open-source AGPL-3.0 project. Following the Contributing rules: working SKILL.md, actively maintained, one-line install, not already listed. Placed in **DevOps & Deployment**, alphabetically adjacent to `nix-hermes-agent`, matching the `[name](repo) by [author] — description **[tag]**` format.

**[nika](https://github.com/supernovae-st/nika)** — a deterministic workflow runner Hermes can delegate repeatable jobs to. Each job is a reviewable `.nika.yaml` file, checked before a token is spent (`nika check` reports the plan, an honest cost floor, secret flows, and the permits boundary) and tamper-evident after (a hash-chained trace `nika trace verify` confirms or breaks). Ships a Hermes skill pack plus a read-only MCP oracle; the offline mock path needs zero keys.

Working example in two commands: `brew install supernovae-st/tap/nika` then `nika examples run 01-hello --model mock/echo`. Tagged **[beta]** honestly (engine is at 0.99, pre-1.0). Happy to adjust category, wording, or tag.