### PR TITLE
Add levea-ai-video-editor to Creative & Media Generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ Web-based workspace with chat, terminal, memory browser, skills manager, and ins
 - [black-forest-labs/skills](https://github.com/black-forest-labs/skills) by [Black Forest Labs](https://github.com/black-forest-labs) — Official FLUX model skills for image generation. First-party skills from the FLUX creators. **[production]**
 - [hermes-weather-plugin](https://github.com/FahrenheitResearch/hermes-weather-plugin) by [FahrenheitResearch](https://github.com/FahrenheitResearch) — Professional-grade weather plugin with NWS model imagery, NEXRAD radar, meteorological calculations. **[beta]**
 - [hermes-wxtrain-plugin](https://github.com/FahrenheitResearch/hermes-wxtrain-plugin) by [FahrenheitResearch](https://github.com/FahrenheitResearch) — ML pipeline for building training datasets from HRRR/GFS/ERA5 weather models. **[experimental]**
+- [levea-ai-video-editor](https://github.com/brajendrak00068/openclaw-ai-video-editor) by [brajendrak00068](https://github.com/brajendrak00068) — Agentic AI video editor for viral clips, captions, silence removal, vertical reframe, chroma key, and MP4 export. **[production]**
 - [typeui-hermes](https://www.typeui.sh/docs/guides/hermes) by [Bergside](https://github.com/bergside/typeui) — Use design skills to generate better UI with Hermes. **[production]**
 
 ### 🔧 DevOps & Deployment


### PR DESCRIPTION
This PR adds the alphabetically ordered entry for **levea-ai-video-editor** skill in the Creative & Media Generation section. Tagged as [production] as the package is live on npm, ClawHub, and MCP registry.