### PR TITLE
Add deep-research to Search & Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,7 @@ Web-based workspace with chat, terminal, memory browser, skills manager, and ins
 - [hermes-web-search-plus](https://github.com/robbyczgw-cla/hermes-web-search-plus) by [robbyczgw-cla](https://github.com/robbyczgw-cla) — Multi-provider web search with intelligent routing across Serper, Tavily, Exa, and more. Replaces built-in search with better quality + source diversity. **[beta]**
 - [Not Human Search](https://github.com/unitedideas/nothumansearch-mcp) by [unitedideas](https://github.com/unitedideas) — MCP server for discovering other MCP servers. Indexes 8,600+ agent-friendly sites with agentic scoring. Lets Hermes find new tools on its own. **[production]**
 - [consensus-mcp-hermes](https://github.com/ahmdngi/consensus-mcp-hermes) by [ahmdngi](https://github.com/ahmdngi) — Connect 200M+ peer-reviewed research papers to Hermes via the Consensus MCP server. OAuth setup guide for headless environments with mcp-remote bridge. **[beta]**
+- [agent-skills/deep-research](https://github.com/moonlight-lupin/agent-skills/tree/main/research/deep-research) by [moonlight-lupin](https://github.com/moonlight-lupin) — Autonomous Think→Search→Extract→Synthesize→Stop research engine producing cited reports. Inspired by PewDiePie's Odysseus. **[production]**
 
 ### 💻 Dev & Skill Authoring
 


### PR DESCRIPTION
## Skill: deep-research

- **Repo:** [moonlight-lupin/agent-skills](https://github.com/moonlight-lupin/agent-skills) (MIT)
- **Path:** `research/deep-research`
- **Category:** 🔍 Search & Research

Autonomous research engine implementing a Think→Search→Extract→Synthesize→Stop loop. Iteratively searches the web, extracts content, synthesizes findings, and decides when enough evidence has been gathered to produce a cited report. Inspired by [PewDiePie's Odysseus](https://github.com/pewdiepie-archdaemon/odysseus) self-hosted AI workspace.

- Pure prompt-only — no API keys, no dependencies beyond Python stdlib
- Tested with evals (routing/output-contract fixtures)
- 681 tests passing across the repo
- **[production]** — stable, production-tested with real workflows
