### PR TITLE
Add skill-maintainer to Dev & Skill Authoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,7 @@ Web-based workspace with chat, terminal, memory browser, skills manager, and ins
 - [hermes-dojo](https://github.com/Yonkoo11/hermes-dojo) by [Yonkoo11](https://github.com/Yonkoo11) — Self-improvement system that monitors agent performance, identifies weak skills, iterates automatically. **[beta]**
 - [hermes-skill-distillation](https://github.com/beardthelion/hermes-skill-distillation) by [beardthelion](https://github.com/beardthelion) — Generates agentic training trajectories from real-world tasks for fine-tuning data. **[beta]**
 - [rtk-hermes](https://github.com/ogallotti/rtk-hermes) by [ogallotti](https://github.com/ogallotti) — Compresses terminal output via RTK before it reaches LLM context. 60-90% token reduction. Zero config. **[beta]**
+- [agent-skills/skill-maintainer](https://github.com/moonlight-lupin/agent-skills/tree/main/agent-ops/skill-maintainer) by [moonlight-lupin](https://github.com/moonlight-lupin) — End-to-end skill library maintenance: author, curate, track upstream drift, publish. **[beta]**
 
 ### 🌐 Browser & Web
 


### PR DESCRIPTION
## Skill: skill-maintainer

- **Repo:** [moonlight-lupin/agent-skills](https://github.com/moonlight-lupin/agent-skills) (MIT)
- **Path:** `agent-ops/skill-maintainer`
- **Category:** 💻 Dev & Skill Authoring → Hermes-native skill builders

End-to-end skill library maintenance: author, curate, track upstream drift, publish. Distinct from SkillClaw (auto-evolution) — this is manual maintenance with upstream drift tracking.

- No dependencies beyond Python stdlib (curl for GitHub API)
- Tested with pytest
- **[beta]** — works but still evolving
