### PR TITLE
Add true402-token-safety — Base rug/honeypot pre-trade check

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,6 +609,7 @@ Web-based workspace with chat, terminal, memory browser, skills manager, and ins
 - [ripley-xmr-gateway](https://github.com/KYC-rip/ripley-xmr-gateway) by [KYC-rip](https://github.com/KYC-rip) — Monero (XMR) blockchain gateway. Private cryptocurrency transactions from agent workflows. **[experimental]**
 - [hermes-blockchain-oracle](https://github.com/gizdusum/hermes-blockchain-oracle) by [gizdusum](https://github.com/gizdusum) — Solana blockchain intelligence MCP server. On-chain analytics and wallet data. **[experimental]**
 - [chainlink-agent-skills](https://github.com/smartcontractkit/chainlink-agent-skills) by [Chainlink](https://github.com/smartcontractkit) — Official Chainlink skills. Oracle data, CCIP, smart contract interaction. **[production]**
+- [true402-token-safety](https://github.com/true402/hermes-skills) by [true402](https://github.com/true402) — Pre-trade rug/honeypot check for Base tokens. Runs a real on-chain buy/sell simulation to prove a token can be sold, plus liquidity and contract structure. Free daily checks, no API key; pays per call over x402 after. **[beta]**
 - [mercury](https://github.com/hxsteric/mercury) by [hxsteric](https://github.com/hxsteric) — Multi-chain blockchain cash flow analyzer with WebGL dashboard. On-chain forensics. **[beta]**
 - [erpclaw](https://github.com/avansaber/erpclaw) by [AvanSaber](https://github.com/avansaber) — AI-native open-source ERP and double-entry accounting you self-host and run in plain English. Invoicing, inventory, general ledger, payroll, multi-company books. **[beta]**
 


### PR DESCRIPTION
Adds `true402-token-safety` to **Finance, Payments & Crypto**.

Installs as a Hermes tap:
```bash
hermes skills tap add true402/hermes-skills
hermes skills install true402/hermes-skills/true402-token-safety
```

What makes it different from static scanners: it runs a **real buy/sell simulation on-chain** (gas-free `eth_call` with state override) to prove a token can actually be *sold*, rather than reading flags — plus liquidity depth and contract structure, returning one avoid/caution/ok verdict.

Free daily checks with no wallet or API key; heavy use pays per call over x402 (USDC on Base, client-side $0.10 cap). Skill repo: https://github.com/true402/hermes-skills · https://true402.dev