### PR TITLE
Add twitr-skills to Communication & Social

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,7 @@ Web-based workspace with chat, terminal, memory browser, skills manager, and ins
 - [hermes-tweet](https://github.com/Xquik-dev/hermes-tweet) by [Xquik](https://github.com/Xquik-dev) — Native Hermes Agent X/Twitter plugin for tweet search, reply reading, user lookup, monitoring, posting, replies, DMs, and approval-gated X actions through Xquik. **[beta]**
 - [microsoft-workspace-skill](https://github.com/Andrew-Girgis/microsoft-workspace-skill) by [Andrew-Girgis](https://github.com/Andrew-Girgis) — Full Outlook/Hotmail/Microsoft 365 integration via Graph API. Email, calendar, contacts, free/busy. OAuth2 auto-refresh. Preview-before-send pattern. **[beta]**
 - [tweetclaw](https://github.com/Xquik-dev/tweetclaw) by [Xquik](https://github.com/Xquik-dev) — OpenClaw plugin and agent skill to scrape tweets, search tweet replies, export followers, look up users, run media, monitors, webhooks, giveaway draws, and approval-gated posts through Xquik. **[beta]**
+- [twitr-skills](https://github.com/lnvestor/twitr-skills) by [lnvestor](https://github.com/lnvestor) — Five X/Twitter skills for agents: live reads and search, bulk dataset exports, real-time account/keyword monitors with signed webhooks, publishing through a connected account, and an unattended presence routine. Pay-per-call in USDC (x402 on Base/Solana, MPP on Tempo) — no API key, no signup. **[production]**
 
 ### 📊 Productivity & Tasks
 


### PR DESCRIPTION
Adding [**twitr-skills**](https://github.com/lnvestor/twitr-skills) — five X/Twitter Agent Skills — to `Communication & Social`, in alphabetical order after `tweetclaw`, using the required entry format.

**Against your four acceptance criteria:**

1. **Working `SKILL.md` in Agent Skills format** — all five validate against the official reference validator:
   ```
   $ npx skills-ref validate ./skills/<name>
   Valid skill: skills/x-presence/
   Valid skill: skills/x-twitter-data/
   Valid skill: skills/x-twitter-monitor/
   Valid skill: skills/x-twitter-publish/
   Valid skill: skills/x-twitter-research/
   ```
   `npx skills add lnvestor/twitr-skills --list` resolves all 5.
2. **Maintained** — pushed today.
3. **Clear README with one-line install** — yes, see below.
4. **Not already listed** — checked; twitr-skills is not on the list.

**Install:**
```bash
hermes skills install skills-sh/lnvestor/twitr-skills/skills/x-twitter-data
```

**The five skills:** `x-twitter-data` (live reads, search, timelines), `x-twitter-research` (23 bulk extractors → downloadable datasets), `x-twitter-monitor` (real-time account/keyword watch, free polling or HMAC-signed webhooks), `x-twitter-publish` (post/reply/quote via a connected account), `x-presence` (unattended posting + monitoring routine, works with Hermes cron).

Each carries explicit anti-triggers cross-referencing the others so they don't cannibalise each other's activations. Backed by https://twitr.sh — pay-per-call in USDC (x402 on Base/Solana, MPP on Tempo), no API key or signup.