### PR TITLE
Add Open Index to memory and knowledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,7 @@ Web-based workspace with chat, terminal, memory browser, skills manager, and ins
 ### 🧠 Memory & Knowledge
 
 - [hindsight](https://github.com/vectorize-io/hindsight) by [Vectorize](https://github.com/vectorize-io) — Long-term memory layer with retain/recall/reflect workflows. Semantic + graph + temporal retrieval. Plugin or MCP. **[production]**
+- [Open Index](https://github.com/DrDroidLab/open-index) by [DrDroidLab](https://github.com/DrDroidLab) — Structured context graphs with hybrid search, read/write MCP access, and a portable setup skill for Hermes. **[beta]**
 - [honcho-self-hosted](https://github.com/elkimek/honcho-self-hosted) by [elkimek](https://github.com/elkimek) — Self-hosted Honcho memory backend setup for Hermes. Stronger cross-session memory with local control. **[beta]**
 - [yantrikdb-hermes-plugin](https://github.com/yantrikos/yantrikdb-hermes-plugin) by [yantrikos](https://github.com/yantrikos) — Hermes-native memory provider for YantrikDB. `think()` canonicalizes duplicates, `conflicts()` surfaces contradictions, every `recall()` carries `why_retrieved` reasons. **[beta]**
 - [plur](https://github.com/plur-ai/plur) by [plur-ai](https://github.com/plur-ai) — Shared memory layer for AI agents with open engram format (YAML). Persistent learning patterns. **[beta]**


### PR DESCRIPTION
## Summary

Add Open Index under Community Skills → Memory & Knowledge, tagged beta. Open Index provides structured context graphs, hybrid search, read/write MCP access, and a portable setup skill explicitly compatible with Hermes.

Project: https://github.com/DrDroidLab/open-index