### PR TITLE
Add hermes-startup skill (first-dollar workflow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,7 @@ Web-based workspace with chat, terminal, memory browser, skills manager, and ins
 - [chainlink-agent-skills](https://github.com/smartcontractkit/chainlink-agent-skills) by [Chainlink](https://github.com/smartcontractkit) — Official Chainlink skills. Oracle data, CCIP, smart contract interaction. **[production]**
 - [mercury](https://github.com/hxsteric/mercury) by [hxsteric](https://github.com/hxsteric) — Multi-chain blockchain cash flow analyzer with WebGL dashboard. On-chain forensics. **[beta]**
 - [erpclaw](https://github.com/avansaber/erpclaw) by [AvanSaber](https://github.com/avansaber) — AI-native open-source ERP and double-entry accounting you self-host and run in plain English. Invoicing, inventory, general ledger, payroll, multi-company books. **[beta]**
+- [hermes-startup](https://github.com/33hodl/hermes-startup) by [33hodl](https://github.com/33hodl) — First-dollar workflow skill: personal profile → ranked idea shortlist → tool selection with prepaid per-call billing; answers stay local; no income guarantee. **[beta]**
 
 ### 🤖 Multi-Agent & Swarms
 


### PR DESCRIPTION
Adds [hermes-startup](https://github.com/33hodl/hermes-startup) to the Finance, Payments & Crypto section.

- Working SKILL.md at repo root (v0.6.1), installable via `hermes skills install` or skills.sh
- Local-first: answers stay in the local profile; prepaid per-call billing; no income guarantee (stated in the skill contract)
- MIT licensed, actively maintained

Follows the list's entry format. Happy to adjust the tag (beta) if maintainers prefer another maturity label.