### PR TITLE
Refresh LintLang listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ Web-based workspace with chat, terminal, memory browser, skills manager, and ins
 - [Agentic-MCP-Skill](https://github.com/cablate/Agentic-MCP-Skill) by [cablate](https://github.com/cablate) — MCP client with agentskills.io validation. **[beta]**
 - [pydantic-ai-skills](https://github.com/DougTrajano/pydantic-ai-skills) by [DougTrajano](https://github.com/DougTrajano) — Pydantic AI with agentskills.io. Type-safe schema validation for skill inputs/outputs. **[production]**
 - [evey-bridge-plugin](https://github.com/42-evey/evey-bridge-plugin) by [42-evey](https://github.com/42-evey) — Claude Code plugin that bridges with Hermes. Shared context, task handoffs. **[beta]**
-- [lintlang](https://github.com/roli-lpci/lintlang) by [roli-lpci](https://github.com/roli-lpci) — Static linter for AI agent configs and prompts with HERM v1.1 scoring. **[beta]**
+- [lintlang](https://github.com/hermes-labs-ai/lintlang) by [Hermes Labs](https://github.com/hermes-labs-ai) — Deterministic local static analysis for authored natural-language agent instructions. **[beta]**
 - [super-hermes](https://github.com/Cranot/super-hermes) by [Cranot](https://github.com/Cranot) — Teaches Hermes to write its own analytical prompts. Meta-reasoning before execution. **[experimental]**
 - [hermes-dojo](https://github.com/Yonkoo11/hermes-dojo) by [Yonkoo11](https://github.com/Yonkoo11) — Self-improvement system that monitors agent performance, identifies weak skills, iterates automatically. **[beta]**
 - [hermes-skill-distillation](https://github.com/beardthelion/hermes-skill-distillation) by [beardthelion](https://github.com/beardthelion) — Generates agentic training trajectories from real-world tasks for fine-tuning data. **[beta]**


### PR DESCRIPTION
Updates the existing LintLang entry to its canonical Hermes Labs repository and replaces the legacy HERM v1.1 wording with a bounded current description. The existing beta label and list placement remain unchanged.

Validation: `git diff --check` passes. Repository-wide `awesome-lint` is not currently green on the default branch's existing format; this one-line change follows that format.
