### PR TITLE
Add windows-terminal-hygiene (Windows anti-hang terminal skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,6 +588,7 @@ Deepfake detection for agents that ingest user-submitted media. Detects AI-gener
 - [SkillClaw](https://github.com/AMAP-ML/SkillClaw) by [AMAP-ML](https://github.com/AMAP-ML) — Auto-evolves and dedupes your skill library from session data. Native Hermes integration. 2.4k★. **[production]**
 - [skillsdotnet](https://github.com/PederHP/skillsdotnet) by [PederHP](https://github.com/PederHP) — C# implementation of agentskills.io with MCP integration. **[beta]**
 - [super-hermes](https://github.com/Cranot/super-hermes) by [Cranot](https://github.com/Cranot) — Teaches Hermes to write its own analytical prompts. Meta-reasoning before execution. **[experimental]**
+- [windows-terminal-hygiene](https://github.com/vollegrewar/windows-terminal-hygiene) by [vollegrewar](https://github.com/vollegrewar) — Pre-flight checklist that keeps agent terminal commands from hanging on Windows: timeouts, non-interactive flags, pty, encoding, and a 3-minute recovery flow. **[beta]**
 - [wondelai/skills](https://github.com/wondelai/skills) by [wondelai](https://github.com/wondelai) — Cross-platform agent skills for Claude Code and agentskills.io platforms. 1.9k★. **[production]**
 
 ### 🌐 Browser & Web


### PR DESCRIPTION
## What are you adding?

**windows-terminal-hygiene** — Pre-flight checklist that keeps agent terminal commands from hanging on Windows.

**Link:** https://github.com/vollegrewar/windows-terminal-hygiene

## Checklist

- [x] **The link works** — public, resolves, not a 404 or an empty repo
- [x] **It has substance** — a real `SKILL.md`, plus a README
- [x] **Not already listed** — I searched the README for the repo name
- [x] **Correct section** — Dev & Skill Authoring, placed alphabetically
- [x] **Format matches** — `- [name](repo-url) by [author](author-url) — one-line description. **[tag]**`

## Tag

`beta`

## Anything we should know?

- I'm the author (vollegrewar) — that's fine and normal.
- Repo is brand new and actively maintained.
- SKILL.md is written in Chinese (targets zh-CN Windows users: GBK code pages, proxy setups, MSYS path conversion); README is bilingual.
- Install: `hermes skills install vollegrewar/windows-terminal-hygiene`
