### PR TITLE
Add OrkasVideoStudio

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,7 @@ Deepfake detection for agents that ingest user-submitted media. Detects AI-gener
 - [hermes-wxtrain-plugin](https://github.com/FahrenheitResearch/hermes-wxtrain-plugin) by [FahrenheitResearch](https://github.com/FahrenheitResearch) — ML pipeline for building training datasets from HRRR/GFS/ERA5 weather models. **[experimental]**
 - [levea-ai-video-editor](https://github.com/brajendrak00068/agentic-ai-video-production/tree/main/skills/media/levea-ai-video-editor) by [brajendrak00068](https://github.com/brajendrak00068) — Agentic video editing: clip selection, captions, silence removal, vertical reframe, chroma key, MP4 export. **[beta]**
 - [lora-concept-removal-tagging](https://github.com/kwanmxiii-bit/Loras-training-tap-skill) by [kwanmxiii-bit](https://github.com/kwanmxiii-bit) — Tags LoRA training images and drops target concepts so the weights absorb them instead. Caption-dropout based. **[beta]**
+- [OrkasVideoStudio](https://github.com/Orkas-AI/Orkas-VideoStudio) by [Orkas-AI](https://github.com/Orkas-AI) — Local-first TypeScript CLI and MCP toolkit with 14 skills for agent-authored video composition, editing, generation, and plan-based assembly. **[beta]**
 - [runapi-cli](https://github.com/runapi-ai/cli-skill) by [RunAPI](https://github.com/runapi-ai) — Runs image, video, music and model API jobs from any CLI-capable agent. **[beta]**
 - [typeui-hermes](https://www.typeui.sh/docs/guides/hermes) by [Bergside](https://github.com/bergside/typeui) — Use design skills to generate better UI with Hermes. **[production]**
 


### PR DESCRIPTION
## Summary
Add OrkasVideoStudio to Creative & Media Generation as a beta, local-first TypeScript CLI and MCP toolkit with 14 agent skills.

## Affiliation
I am submitting this on behalf of the Orkas project.

## Checklist
- [x] Public canonical repository
- [x] Real SKILL.md files and documentation
- [x] Active within six months
- [x] Duplicate search completed