### PR TITLE
Refresh UIZZE entry with current free/full scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,7 +623,7 @@ Deepfake detection for agents that ingest user-submitted media. Detects AI-gener
 
 ### 🎨 Creative & Media Generation
 
-- [anti-ui-slop](https://github.com/uizze/uizze) by [UIZZE](https://github.com/uizze) — Free MIT Skill for product-specific design contracts, required UI states, and hard finish gates; its no-account preview is at https://uizze.com/mcp/preview, while full [UIZZE](https://uizze.com) adds live reference search, validation, and audits across 800,000+ real web and iOS screens. **[beta]**
+- [anti-ui-slop](https://github.com/uizze/uizze) by [UIZZE](https://github.com/uizze) — MIT skill for design contracts, required UI states and hard finish gates on agent-generated UI. Works without an account; live reference search, validation and audits need the paid [UIZZE](https://uizze.com) MCP. **[beta]**
 - [black-forest-labs/skills](https://github.com/black-forest-labs/skills) by [Black Forest Labs](https://github.com/black-forest-labs) — Official FLUX model skills for image generation. First-party skills from the FLUX creators. **[production]**
 - [hermes-weather-plugin](https://github.com/FahrenheitResearch/hermes-weather-plugin) by [FahrenheitResearch](https://github.com/FahrenheitResearch) — Professional-grade weather plugin with NWS model imagery, NEXRAD radar, meteorological calculations. **[beta]**
 - [hermes-wxtrain-plugin](https://github.com/FahrenheitResearch/hermes-wxtrain-plugin) by [FahrenheitResearch](https://github.com/FahrenheitResearch) — ML pipeline for building training datasets from HRRR/GFS/ERA5 weather models. **[experimental]**

--- a/README.md
+++ b/README.md
@@ -623,7 +623,7 @@ Deepfake detection for agents that ingest user-submitted media. Detects AI-gener
 
 ### 🎨 Creative & Media Generation
 
-- [anti-ui-slop](https://github.com/uizze/uizze) by [UIZZE](https://github.com/uizze) — Design finish-gate that checks agent-generated UI against a reference set of real web and iOS screens. Free skill works without an account; live reference search needs the paid [UIZZE](https://uizze.com) MCP. **[beta]**
+- [anti-ui-slop](https://github.com/uizze/uizze) by [UIZZE](https://github.com/uizze) — Free MIT Skill for product-specific design contracts, required UI states, and hard finish gates; its no-account preview is at https://uizze.com/mcp/preview, while full [UIZZE](https://uizze.com) adds live reference search, validation, and audits across 800,000+ real web and iOS screens. **[beta]**
 - [black-forest-labs/skills](https://github.com/black-forest-labs/skills) by [Black Forest Labs](https://github.com/black-forest-labs) — Official FLUX model skills for image generation. First-party skills from the FLUX creators. **[production]**
 - [hermes-weather-plugin](https://github.com/FahrenheitResearch/hermes-weather-plugin) by [FahrenheitResearch](https://github.com/FahrenheitResearch) — Professional-grade weather plugin with NWS model imagery, NEXRAD radar, meteorological calculations. **[beta]**
 - [hermes-wxtrain-plugin](https://github.com/FahrenheitResearch/hermes-wxtrain-plugin) by [FahrenheitResearch](https://github.com/FahrenheitResearch) — ML pipeline for building training datasets from HRRR/GFS/ERA5 weather models. **[experimental]**


### PR DESCRIPTION
## What changed

Refreshes the existing `anti-ui-slop` entry in Creative & Media Generation with current, source-backed copy:

- identifies the Skill as MIT and free to use
- links the no-account preview MCP
- distinguishes full UIZZE live reference search, validation, and audits across 800,000+ real web and iOS screens

This follows the repository’s one-line entry format and changes no other listing. I build UIZZE and am disclosing the first-party relationship.

## Checks

- `git diff --check`
- source repository and preview link verified
- UIZZE has an active commit within the repository’s six-month maintenance window