### PR TITLE
add aivpn: per-location Docker WireGuard relay for Proton VPN

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,7 @@ Deepfake detection for agents that ingest user-submitted media. Detects AI-gener
 
 ### 🔧 DevOps & Deployment
 
+- [aivpn](https://github.com/ZoniBoy00/aivpn) by [ZoniBoy00](https://github.com/ZoniBoy00) — Per-location Docker WireGuard relay for Proton VPN with kill switch, SOCKS5 and prompt-injection-safe fetching. **[beta]**
 - [evey-setup](https://github.com/42-evey/evey-setup) by [42-evey](https://github.com/42-evey) — One-command setup for full hermes-agent stack with free models and 29 plugins. **[beta]**
 - [hermes-agent-docker](https://github.com/xmbshwll/hermes-agent-docker) by [xmbshwll](https://github.com/xmbshwll) — Minimal Docker sandbox image for Hermes. Pull, run, done. **[beta]**
 - [nika](https://github.com/supernovae-st/nika) by [supernovae-st](https://github.com/supernovae-st) — Deterministic workflow runner Hermes can delegate to. Repeatable jobs become reviewable `.nika.yaml` files with plan, cost and permit checks up front and a hash-chained trace after. **[beta]**


### PR DESCRIPTION
## What
Adds [ZoniBoy00/aivpn](https://github.com/ZoniBoy00/aivpn) to the **DevOps & Deployment** section.

One Docker container = one WireGuard tunnel to a Proton VPN exit node, with:
- iptables kill switch (container goes dark if the tunnel drops — never leaks to host)
- microsocks SOCKS5 proxy
- `safefetch` prompt-injection-safe fetching for agents
- works with any Proton VPN WireGuard config (free plan included), no API keys

The repo ships a `SKILL.md` (installs via `hermes skills install ZoniBoy00/aivpn/aivpn`), so it qualifies as a community skill entry.

## Checklist
- [x] 1. Link resolves to a public repo with substance (SKILL.md + README + working code, tested on a Hetzner VPS)
- [x] 2. Actively maintained (initial release + fixes this week)
- [x] 3. Not already listed (searched — no aivpn entry)
- [x] 4. Tag honest: **[beta]** — works and is tested, but young (first release Aug 2026)