### PR TITLE
Add Scavio to Search & Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ Deepfake detection for agents that ingest user-submitted media. Detects AI-gener
 - [deep-research](https://github.com/moonlight-lupin/agent-skills/tree/main/research/deep-research) by [moonlight-lupin](https://github.com/moonlight-lupin) — Autonomous Think→Search→Extract→Synthesize→Stop loop that produces cited research reports. **[production]**
 - [hermes-web-search-plus](https://github.com/robbyczgw-cla/hermes-web-search-plus) by [robbyczgw-cla](https://github.com/robbyczgw-cla) — Multi-provider web search with intelligent routing across Serper, Tavily, Exa, and more. Replaces built-in search with better quality + source diversity. **[beta]**
 - [Not Human Search](https://github.com/unitedideas/nothumansearch-mcp) by [unitedideas](https://github.com/unitedideas) — MCP server for discovering other MCP servers. Indexes 8,600+ agent-friendly sites with agentic scoring. Lets Hermes find new tools on its own. **[production]**
+- [Scavio](https://github.com/scavio-ai/hermes-agent) by [scavio-ai](https://github.com/scavio-ai) — Structured web data from 31 platforms through one hosted MCP server: Google SERP, Amazon, Walmart, eBay, Reddit, YouTube, TikTok, LinkedIn, Zillow, SEC filings and more, plus five workflow skills for product research, competitor scans and price tracking. **[beta]**
 
 ### 📈 Marketing & Growth
 

--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ Deepfake detection for agents that ingest user-submitted media. Detects AI-gener
 - [deep-research](https://github.com/moonlight-lupin/agent-skills/tree/main/research/deep-research) by [moonlight-lupin](https://github.com/moonlight-lupin) — Autonomous Think→Search→Extract→Synthesize→Stop loop that produces cited research reports. **[production]**
 - [hermes-web-search-plus](https://github.com/robbyczgw-cla/hermes-web-search-plus) by [robbyczgw-cla](https://github.com/robbyczgw-cla) — Multi-provider web search with intelligent routing across Serper, Tavily, Exa, and more. Replaces built-in search with better quality + source diversity. **[beta]**
 - [Not Human Search](https://github.com/unitedideas/nothumansearch-mcp) by [unitedideas](https://github.com/unitedideas) — MCP server for discovering other MCP servers. Indexes 8,600+ agent-friendly sites with agentic scoring. Lets Hermes find new tools on its own. **[production]**
-- [Scavio](https://github.com/scavio-ai/hermes-agent) by [scavio-ai](https://github.com/scavio-ai) — Structured web data from 31 platforms through one hosted MCP server: Google SERP, Amazon, Walmart, eBay, Reddit, YouTube, TikTok, LinkedIn, Zillow, SEC filings and more, plus five workflow skills for product research, competitor scans and price tracking. **[beta]**
+- [Scavio](https://github.com/scavio-ai/hermes-agent) by [scavio-ai](https://github.com/scavio-ai) — Structured web data from 31 platforms through one hosted MCP server: search, retail, social, property and SEC filings, plus five research workflow skills. Credit-metered, with 50 free credits on signup. **[beta]**
 
 ### 📈 Marketing & Growth
 


### PR DESCRIPTION
One entry under **Search & Research**.

**What it is:** Scavio gives Hermes structured web data from 31 platforms through one hosted MCP server (`mcp.scavio.dev`, streamable HTTP) plus five workflow skills — product deep research, competitive intel, price-drop watch, Reddit sentiment, YouTube digest.

Against the four criteria:

1. **Link resolves** — https://github.com/scavio-ai/hermes-agent, public, MIT.
2. **Substance** — five `SKILL.md` files with references, a root `plugin.json` (Agent Plugins 1.0.0), a config snippet, and install docs. The 39 underlying platform skills are also published on ClawHub, so `hermes skills search scavio` finds them and `hermes skills install @scavio-ai/scavio-amazon` works without `--force`.
3. **Maintained** — active; the repo was published this week.
4. **Not a duplicate** — searched the page for "scavio", no existing entry.

Tagged **[beta]** rather than production: the API and the ClawHub skills are mature, but this repo is new, and that seemed the honest call.

Happy to adjust the wording or move it to a different section if Search & Research is the wrong home.