### PR TITLE
Add Verified Memory Vault to Security & Detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,7 @@ Deepfake detection for agents that ingest user-submitted media. Detects AI-gener
 - [hermes-agent-camel](https://github.com/nativ3ai/hermes-agent-camel) by [nativ3ai](https://github.com/nativ3ai) — Hermes with integrated CaMeL trust boundaries. Formal trust verification for safety-critical deployments. **[beta]**
 - [incognito-mode](https://github.com/GenmetsuWenxuePress/hermes-skills) by [幻灭文学出版社](https://github.com/GenmetsuWenxuePress) — Defense-in-depth incognito mode: PID-locked sandbox, shell history suppression, 10-step reverse audit with Python secure wipe, subagent inheritance protocol. **[beta]**
 - [resemble-ai/detect-skill](https://github.com/resemble-ai/detect-skill) by [Resemble AI](https://github.com/resemble-ai) — Deepfake detection: AI-generated audio/image/video/text, source tracing, watermarking, speaker ID. **[beta]**
+- [Verified Memory Vault](https://github.com/secondbrainstarter/verified-memory-vault) by [secondbrainstarter](https://github.com/secondbrainstarter) — Plain-Markdown Obsidian vault that gives AI coding agents persistent memory, with a health checker (protocol violations, dead links, bloat) and a git pre-commit hook that refuses commits mass-deleting memory files. **[beta]**
 
 ### 🎯 Domain & Novelty
 


### PR DESCRIPTION
Adds Verified Memory Vault (https://github.com/secondbrainstarter/verified-memory-vault) to the **Security & Detection** section.

What it is: a free, plain-Markdown Obsidian vault that gives AI coding agents persistent memory with an integrity layer — `memory_check.py` audits a memory directory for protocol violations, dead links and bloat, and `memory_guard.py` is a git pre-commit hook that refuses commits which mass-delete memory files. No Node, no plugins, stdlib Python only.

Why this section: the threat model it addresses is an agent (or a careless cleanup pass) silently rewriting or destroying its own memory/history — the guard makes tampering visible at commit time, which is detection tooling for exactly that class of failure. Tagged beta honestly: released v0.9.0 this week, small user base so far.

Single-file addition (+1 line under Security & Detection, after detect-skill). Checked the page first — not listed yet.