### PR TITLE
Add hermes-conductor to Multi-Agent & Swarms

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@ Deepfake detection for agents that ingest user-submitted media. Detects AI-gener
 
 ### 🤖 Multi-Agent & Swarms
 
+- [hermes-conductor](https://github.com/forcewake/hermes-conductor) by [forcewake](https://github.com/forcewake) — Kanban-orchestrated multi-harness coding swarm: controller/worker/reviewer skills with evidence-only task completion. **[beta]**
 - [hermes-council](https://github.com/Ridwannurudeen/hermes-council) by [Ridwannurudeen](https://github.com/Ridwannurudeen) — Adversarial multi-perspective council MCP. Multiple AI viewpoints debate before commit. **[experimental]**
 - [NemoHermes](https://github.com/Hmbown/NemoHermes) by [Hmbown](https://github.com/Hmbown) — NVIDIA capability registry and Spark-aware routing. Routes compute-heavy tasks to GPU infrastructure. **[experimental]**
 - [opencode-hermes-multiagent](https://github.com/1ilkhamov/opencode-hermes-multiagent) by [1ilkhamov](https://github.com/1ilkhamov) — 17 specialized agents for OpenCode AI with structured interfaces. **[beta]**


### PR DESCRIPTION
Adds [hermes-conductor](https://github.com/forcewake/hermes-conductor) — kanban-orchestrated multi-harness coding swarm patterns plus two installable skills (`kanban-orchestrator`, `kanban-worker`).

Against the bar:

- **Link resolves** — public repo, MIT.
- **Something behind it** — two `skills/*/SKILL.md`s, seven pattern docs, a cheatsheet, an annotated demo (asciinema cast + narrated cut), and a [v0.1.0 release](https://github.com/forcewake/hermes-conductor/releases/tag/v0.1.0).
- **Maintained** — released two days ago; the patterns come from ~3 months of daily production use (8 profiles, 4 gateways).
- **Not a duplicate** — searched the page for "conductor" and "forcewake"; the only hit is maestro, a different project.

Happy to adjust the line or tag if you'd phrase it differently.