### PR TITLE
docs: add Hermes AI Usage Monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -751,6 +751,7 @@ Deepfake detection for agents that ingest user-submitted media. Detects AI-gener
 > Where Hermes actually meets you — clients, dashboards, chat platforms and devices that talk to a running Hermes gateway.
 
 - [adebnar/hermes-android](https://github.com/adebnar/hermes-android) by [adebnar](https://github.com/adebnar) — Native Android client for the gateway: chat plus sessions, models, cron and usage over Tailscale. **[beta]**
+- [Hermes AI Usage Monitor](https://github.com/masterlf/hermes-ai-usage) by [masterlf](https://github.com/masterlf) — Read-only provider quota and per-profile token telemetry for Hermes Desktop and Web Dashboard, with cache-aware history and no prompt-content collection. **[beta]**
 - [hermes-dashboard](https://github.com/chrisryugj/hermes-dashboard) by [chrisryugj](https://github.com/chrisryugj) — Web dashboard for gateway config, MCP, cron and model management without touching the CLI. **[beta]**
 - [hermes-desktop-avatar](https://github.com/erenciracioglu-dotcom/hermes-desktop-avatar) by [erenciracioglu-dotcom](https://github.com/erenciracioglu-dotcom) — Always-on-top desktop sprite that fronts a local gateway. PySide6, OpenAI-compatible HTTP. **[experimental]**
 - [hermes-live-discord-agent-plugin](https://github.com/Capslockb/hermes-live-discord-agent-plugin) by [Capslockb](https://github.com/Capslockb) — Full-duplex Discord voice with function calling and idle hangup. **[beta]**


### PR DESCRIPTION
## Addition
Adds one beta entry under **Surfaces & Integrations** for [Hermes AI Usage Monitor](https://github.com/masterlf/hermes-ai-usage).

- [x] Public link that resolves
- [x] Real implementation and README
- [x] Active within the last six months
- [x] Not already listed
- [x] Maturity is accurately labeled `beta`

The project exposes read-only provider quota and per-profile token telemetry for Hermes Desktop and Web Dashboard. Installation uses the published release archive and its transactional installer; it is **not** installed through a native Hermes plugin index. The linked repository includes the Apache-2.0 license, release v0.7.3, provenance/checksum material, and CI/security documentation.
