### PR TITLE
Add SandBase CLI Hermes integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,6 +775,7 @@ Deepfake detection for agents that ingest user-submitted media. Detects AI-gener
 - [mission-control](https://github.com/builderz-labs/mission-control) by [builderz-labs](https://github.com/builderz-labs) — Open-source dashboard for AI agent orchestration. Multi-agent fleets, task dispatch, cost tracking. 6.1k★. **[production]**
 - [orahermes-agent](https://github.com/jasperan/orahermes-agent) by [jasperan](https://github.com/jasperan) — Oracle AI Agent Harness — OCI GenAI and Oracle 26ai integration. **[experimental]**
 - [portable-hermes-agent](https://github.com/aivrar/portable-hermes-agent) by [aivrar](https://github.com/aivrar) — Windows desktop app bundling 100 tools, GUI, local models, ComfyUI in a portable package. **[beta]**
+- [sandbase-cli](https://github.com/sandbaseai/cli) by [sandbaseai](https://github.com/sandbaseai) — CLI and local MCP bridge that connects Hermes to 2,000+ AI models and APIs, with managed client setup and OAuth. **[beta]**
 
 ---
 


### PR DESCRIPTION
Adds SandBase CLI to Tools, Workspaces & GUIs.

- Official CLI and local MCP bridge for Hermes
- Connects Hermes to 2,000+ AI models and APIs
- OAuth-backed managed client setup
- Repository is active and includes a working Hermes client target

The entry follows the required one-line format and uses the beta maturity label.