### PR TITLE
Add causal-memory (Memory Providers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -729,6 +729,7 @@ Deepfake detection for agents that ingest user-submitted media. Detects AI-gener
 > Swap-in backends for Hermes's memory layer. A provider changes what the agent remembers and how it recalls it — install one and the built-in memory tools route through it.
 
 - [agentcairn](https://github.com/ccf/agentcairn) by [ccf](https://github.com/ccf) — Long-term cross-project memory backed by your own Obsidian vault. Daemonless, plain files, no opaque store. **[beta]**
+- [causal-memory](https://github.com/JingxuanC/causal-memory/tree/main/hermes-plugin) by [JingxuanC](https://github.com/JingxuanC) — Memory provider with a causal core: flat facts plus typed decision→outcome causal edges (caused / enabled / prevented) on one local SQLite store. Survives compaction structurally — the store lives outside the context window. **[beta]**
 - [flowstate-qmd](https://github.com/amanning3390/flowstate-qmd) by [amanning3390](https://github.com/amanning3390) — Anticipatory memory with RAG and vector search. Pre-fetches relevant context before queries hit the agent. **[beta]**
 - [hermes-membase](https://github.com/aristoapp/hermes-membase) by [aristoapp](https://github.com/aristoapp) — Persistent memory provider backed by Membase. **[beta]**
 - [hindsight](https://github.com/vectorize-io/hindsight) by [Vectorize](https://github.com/vectorize-io) — Long-term memory layer with retain/recall/reflect workflows. Semantic + graph + temporal retrieval. Plugin or MCP. **[production]**


### PR DESCRIPTION
## What are you adding?

**causal-memory** — a Hermes `MemoryProvider` plugin that gives the agent a causal memory core: flat facts plus typed decision→outcome causal edges (caused / enabled / prevented) on one local SQLite store.

**Link:** https://github.com/JingxuanC/causal-memory/tree/main/hermes-plugin

## Checklist

- [x] **The link works** — public, resolves, not a 404 or an empty repo
- [x] **It has substance** — a real `SKILL.md` / `plugin.json` / provider implementation, plus a README
- [x] **Not already listed** — I searched the README for the repo name
- [x] **Correct section** — and placed alphabetically inside it
- [x] **Format matches** — `- [name](repo-url) by [author](author-url) — one-line description. **[tag]**`

## Tag

`beta`

## Anything we should know?

- I'm the author of causal-memory.
- The plugin lives in `hermes-plugin/` of the causal-memory repo, so the entry links straight to that directory. It implements the Hermes `MemoryProvider` interface with wired hooks (system-prompt causal directory, budgeted prefetch recall, non-blocking write-behind) on a per-profile local SQLite store that lives outside the context window, so it survives Hermes compaction structurally.
- Tagged `beta` rather than `production`: the project is actively maintained (368 tests passing, prebuilt releases) but still pre-1.0 (v0.9.2), so edges may move.
