### PR TITLE
Add Codex Skin to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,6 +699,7 @@ Deepfake detection for agents that ingest user-submitted media. Detects AI-gener
 
 - [babysitter](https://github.com/a5c-ai/babysitter) by [a5c-ai](https://github.com/a5c-ai) — Deterministic supervision loop for agentic workforces: enforces plans, retries and completion criteria on long multi-step runs. **[production]**
 - [cronalytics](https://github.com/8bit64k/cronalytics) by [8bit64k](https://github.com/8bit64k) — Analytics and observability for Hermes cron jobs. A dashboard for automations you'd otherwise never see fail. **[beta]**
+- [Codex Skin](https://github.com/FPSUnleashed/hermes-codex-skin) by [FPSUnleashed](https://github.com/FPSUnleashed) — Codex-inspired visual layer for Hermes Desktop with native themes, Glass background support and configurable chat layout styling. **[production]**
 - [hermes-code-bridge](https://github.com/xuyang-liu16/hermes-code-bridge) by [xuyang-liu16](https://github.com/xuyang-liu16) — Makes Hermes the control plane for local coding agents — Codex, Claude Code, OpenCode, Gemini CLI, Kimi Code. **[beta]**
 - [Hermes Connector](https://github.com/CorsenAI/hermes-connector) by [Corsen AI](https://github.com/CorsenAI) — Connects an exact Hermes profile and session to user-selected Chrome tabs through a local companion and authenticated loopback broker. **[production]**
 - [hermes-curator-evolver](https://github.com/pingchesu/hermes-curator-evolver) by [pingchesu](https://github.com/pingchesu) — Evidence-driven skill evolution: reports, dry-run proposals, candidate search and guarded apply. **[beta]**


### PR DESCRIPTION
## What are you adding?

**Codex Skin** — an independent Hermes Desktop plugin that adds a Codex-inspired chat layout and visual styling while preserving Hermes' native behavior, themes, Glass background, model and Thinking Level menus, and composer controls.

**Link:** https://github.com/FPSUnleashed/hermes-codex-skin

## Checklist

- [x] **The link works** — public, resolves, not a 404 or an empty repo
- [x] **It has substance** — includes a supported Hermes Desktop plugin entry point, plugin implementation, README, screenshots, tests, release artifacts and an MIT license
- [x] **Not already listed** — I searched the README for the repository and project name
- [x] **Correct section** — Plugins, placed alphabetically after `cronalytics` and before `hermes-code-bridge`
- [x] **Format matches** — `- [name](repo-url) by [author](author-url) — one-line description. **[tag]**`

## Tag

`production`

## Anything we should know?

- I am the author and owner of FPSUnleashed.
- Codex Skin is an independent community plugin and is not affiliated with or endorsed by Nous Research or OpenAI.
- The current release is v1.3.1 and is described as stable in the project README.
- It uses Hermes' supported Desktop Plugin SDK entry point and does not modify Hermes source files.
- It preserves Hermes-native behavior for model selection, Thinking Level selection, assistant rendering, Queue handling, auto-speak, wake-word controls, and other native surfaces.
- It supports native Hermes themes and the native Glass background. The original Codex palettes are available through the Codex Skin theme.
- The plugin does not use a backend, make network requests, or load external assets.
- Styling depends partly on internal Hermes Desktop DOM attributes, so future Hermes UI changes may require selector maintenance.
